### PR TITLE
Fix project form button type

### DIFF
--- a/src/app/project/projec-form/projec-form.component.html
+++ b/src/app/project/projec-form/projec-form.component.html
@@ -3,7 +3,7 @@
   <div mat-dialog-content>
     <mat-form-field>
       <input type="text" matInput placeholder="Browse" formControlName="path" (click)="selectPath()">
-      <button mat-button mat-icon-button matSuffix (click)="selectPath()" [disabled]="getPathState()">
+      <button mat-button mat-icon-button matSuffix type="button" (click)="selectPath()" [disabled]="getPathState()">
         <mat-icon>more_horiz</mat-icon>
       </button>
       <mat-error *ngIf="path.hasError('required')">


### PR DESCRIPTION
Add the `type="button"` to the button to select the project path because cancelling the selection of the folder was causing to submit the form with an empty path